### PR TITLE
Add `--ignore-hp` option

### DIFF
--- a/severus/bam_processing.py
+++ b/severus/bam_processing.py
@@ -61,7 +61,7 @@ class ReadSegment(object):
             sign = -1 if self.strand == 1 else 1
         return ref_bp, ref_bp_ori, sign
     
-def get_segment(read, genome_id,sv_size,use_supplementary_tag, ref_ind):
+def get_segment(read, genome_id,sv_size,use_supplementary_tag, ref_ind, ignore_hp):
     """
     Parses cigar and generate ReadSegment structure with alignment coordinates
     """
@@ -109,9 +109,9 @@ def get_segment(read, genome_id,sv_size,use_supplementary_tag, ref_ind):
         
     haplotype = 0
     PS = 0
-    if use_tag and read.has_tag('HP'):
+    if not ignore_hp and use_tag and read.has_tag('HP'):
         haplotype = int(read.get_tag('HP'))
-    if use_tag and read.has_tag('PS'):
+    if not ignore_hp and use_tag and read.has_tag('PS'):
         PS = read.get_tag('PS')
     
     read_inf = []
@@ -283,7 +283,7 @@ def extract_clipped_end(segments_by_read):
             read[-1].is_pass = 'PASS'
         read.sort(key=lambda s: s.read_start)
         
-def get_cov(bam_file, genome_id, ref_id, poslist, min_mapq):
+def get_cov(bam_file, genome_id, ref_id, poslist, min_mapq, ignore_hp):
     region_start, region_end = max(0, poslist[0]-3), poslist[-1]+3
     aln_file = pysam.AlignmentFile(bam_file, "rb")
     cov_list = defaultdict(list)
@@ -318,7 +318,9 @@ def get_cov(bam_file, genome_id, ref_id, poslist, min_mapq):
                 strt = bisect.bisect_right(poslist, aln.reference_start)
                 end = bisect.bisect_left(poslist, aln.reference_end)
                 if not strt == end:
-                    if aln.has_tag('HP'):
+                    if ignore_hp:
+                        hp = 0
+                    elif aln.has_tag('HP'):
                         hp = int(aln.get_tag('HP'))
                     else:
                         hp = 0
@@ -328,7 +330,7 @@ def get_cov(bam_file, genome_id, ref_id, poslist, min_mapq):
     return cov_list
 
 
-def get_coverage_parallel(bam_files, genome_ids, thread_pool, min_mapq, double_breaks):
+def get_coverage_parallel(bam_files, genome_ids, thread_pool, min_mapq, double_breaks, ignore_hp):
     db_list = defaultdict(list)
     covlist = defaultdict(list)
     for db in double_breaks:
@@ -342,7 +344,7 @@ def get_coverage_parallel(bam_files, genome_ids, thread_pool, min_mapq, double_b
         db_list[key] = [lst[start:end] for start, end in zip([0] + indices, indices + [len(lst)])]
     for genome_id in genome_ids:
         covlist = defaultdict(list)
-        tasks = [(bam_files[genome_id], genome_id, ref_id, pos, min_mapq) for ref_id, poslist in db_list.items() for pos in poslist]
+        tasks = [(bam_files[genome_id], genome_id, ref_id, pos, min_mapq, ignore_hp) for ref_id, poslist in db_list.items() for pos in poslist]
         parsing_results = None
         parsing_results = thread_pool.starmap(get_cov, tasks)
         for item in parsing_results:
@@ -353,7 +355,7 @@ def get_coverage_parallel(bam_files, genome_ids, thread_pool, min_mapq, double_b
             db.bp_2.spanning_reads[genome_id] = covlist[(db.bp_2.ref_id, db.bp_2.position)]
     
         
-def get_all_reads(bam_file, region, genome_id,sv_size,use_supplementary_tag):
+def get_all_reads(bam_file, region, genome_id,sv_size,use_supplementary_tag, ignore_hp):
     """
     Yields set of split reads for each contig separately. Only reads primary alignments
     and infers the split reads from SA alignment tag
@@ -368,7 +370,7 @@ def get_all_reads(bam_file, region, genome_id,sv_size,use_supplementary_tag):
     t=0
     for aln in aln_file.fetch(ref_id, region_start, region_end,  multiple_iterators=True):
         if not aln.is_secondary and not aln.is_unmapped:
-            new_segment, read_inf = get_segment(aln, genome_id, sv_size,use_supplementary_tag, ref_ind)
+            new_segment, read_inf = get_segment(aln, genome_id, sv_size, use_supplementary_tag, ref_ind, ignore_hp)
             if new_segment:
                 alignments += new_segment
             if not len(read_inf):
@@ -397,6 +399,7 @@ def get_all_reads_parallel(bam_file, thread_pool, ref_lengths, genome_id,
     CHUNK_SIZE = 10000000
     sv_size = args.sv_size
     use_supplementary_tag = args.use_supplementary_tag
+    ignore_hp = args.ignore_hp
     
     all_reference_ids = [r for r in pysam.AlignmentFile(bam_file, "rb").references]
     fetch_list = []
@@ -408,7 +411,7 @@ def get_all_reads_parallel(bam_file, thread_pool, ref_lengths, genome_id,
             if ctg_len - reg_end < CHUNK_SIZE:
                 reg_end = ctg_len
             fetch_list.append((j, ctg, reg_start, reg_end))
-    tasks = [(bam_file, region, genome_id,sv_size,use_supplementary_tag) for region in fetch_list]
+    tasks = [(bam_file, region, genome_id, sv_size, use_supplementary_tag, ignore_hp) for region in fetch_list]
     parsing_results = None
     parsing_results = thread_pool.starmap(get_all_reads, tasks)
     segments_by_read = defaultdict(list)

--- a/severus/breakpoint_finder.py
+++ b/severus/breakpoint_finder.py
@@ -2852,7 +2852,7 @@ def call_breakpoints(segments_by_read, ref_lengths, coverage_histograms, bam_fil
     logger.info('Starting compute_bp_coverage')
     if args.vntr_file:
         add_vntr_annot(double_breaks + ins_clusters, args)
-    get_coverage_parallel(bam_files, genome_ids, thread_pool, args.min_mapping_quality, double_breaks + ins_clusters + single_bps)
+    get_coverage_parallel(bam_files, genome_ids, thread_pool, args.min_mapping_quality, double_breaks + ins_clusters + single_bps, args.ignore_hp)
 
         
     logger.info('Filtering breakpoints')
@@ -2867,7 +2867,8 @@ def call_breakpoints(segments_by_read, ref_lengths, coverage_histograms, bam_fil
     annotate_mut_type(double_breaks, cont_id, args.control_vaf, args.vaf_thr, args.bp_min_support, args.pon_file, ref_lengths)
 
     logger.info('Writing breakpoints')
-    output_breaks(double_breaks + single_bps, genome_ids, args.phase_vcf, open(os.path.join(args.out_dir,"breakpoints_double.csv"), "w"))
+    effective_phasing = bool(args.phase_vcf) and not args.ignore_hp
+    output_breaks(double_breaks + single_bps, genome_ids, effective_phasing, open(os.path.join(args.out_dir,"breakpoints_double.csv"), "w"))
     
     double_breaks = filter_fail_double_db(double_breaks, single_bps, coverage_histograms, segments_by_read, bam_files, thread_pool, args)
     return double_breaks

--- a/severus/build_graph.py
+++ b/severus/build_graph.py
@@ -652,7 +652,8 @@ def output_graphs(db_list, coverage_histograms, thread_pool, target_genomes, con
         for db in double_breaks:
             db.cluster_id = 0
         
-        (genomic_segments, adj_segments) = get_genomic_segments(double_breaks, coverage_histograms, args.phase_vcf,
+        phase_vcf_for_graph = None if args.ignore_hp else args.phase_vcf
+        (genomic_segments, adj_segments) = get_genomic_segments(double_breaks, coverage_histograms, phase_vcf_for_graph,
                                                                 key, ref_lengths, args.max_genomic_len, args.min_sv_size, args.junction_vcf)
         components_list = []
         if key == 'germline':

--- a/severus/main.py
+++ b/severus/main.py
@@ -120,6 +120,8 @@ def main():
                         default=MAX_GENOMIC_LEN, metavar="int", type=int,
                         help=f"maximum length of genomic segment to form connected components [{MAX_GENOMIC_LEN}]")
     parser.add_argument("--phasing-vcf", dest="phase_vcf", metavar="path", help="path to vcf file used for phasing (if using haplotype specific SV calling)[None]")
+    parser.add_argument("--ignore-hp", dest="ignore_hp", action="store_true",
+                        help="Ignore BAM HP/PS tags and treat the run as unphased; overrides --phasing-vcf outputs")
     parser.add_argument("--vntr-bed", dest="vntr_file", metavar="path", help="bed file with tandem repeat locations [None]")
     parser.add_argument("--TIN-ratio", dest='control_vaf', metavar="float", type=float, default = CONTROL_VAF, help = 'Tumor in normal ratio[{CONTROL_VAF}]')
     parser.add_argument("--control-cov-thr", dest='cov_thr', metavar="float", type=int, default = CONTROL_COV_THR, help = 'Min normal coverage[{CONTROL_COV_THR}]')

--- a/severus/vcf_output.py
+++ b/severus/vcf_output.py
@@ -245,7 +245,7 @@ class vcf_sample(object):
         return f"{self.GT}:{self.vaf:.2f}:{self.hVAF()}:{self.DR}:{self.DV}"
     
     
-def db_2_vcf(double_breaks, no_ins, sample_ids, multisample, junction_vcf, germline_genotype):
+def db_2_vcf(double_breaks, no_ins, sample_ids, multisample, junction_vcf, germline_genotype, ignore_hp):
     vcf_list = []
     clusters = defaultdict(list)
     bnd_types = {'-+': 'DUP_LIKE', '+-': 'DEL_LIKE', '++': 'INV_LIKE', '--': 'INV_LIKE'}
@@ -338,6 +338,9 @@ def db_2_vcf(double_breaks, no_ins, sample_ids, multisample, junction_vcf, germl
                 gen_type2 = '1' if 1 in hap_type else '2'
             phaseset = db.phaseset_id
         haplotype = (db.haplotype_1, db.haplotype_2)
+        if ignore_hp:
+            phaseset = ''
+            haplotype = None
         
         drls = [[str(s) for s in db.bp_1.spanning_reads[db.genome_id][:3]], [str(s) for s in db.bp_2.spanning_reads[db.genome_id][:3]]]
         dvls = [[str(s) for s in db.dvls[0]], [str(s) for s in db.dvls[1]]]
@@ -506,8 +509,8 @@ def write_germline_vcf(vcf_list, outfile,ref_lengths):
     outfile.close()
     
     
-def write_to_vcf(double_breaks, all_ids, outpath, out_key, ref_lengths, no_ins, multisample, junction_vcf, germline_genotype):            
-    vcf_list = db_2_vcf(double_breaks, no_ins, all_ids, multisample, junction_vcf, germline_genotype)
+def write_to_vcf(double_breaks, all_ids, outpath, out_key, ref_lengths, no_ins, multisample, junction_vcf, germline_genotype, ignore_hp):            
+    vcf_list = db_2_vcf(double_breaks, no_ins, all_ids, multisample, junction_vcf, germline_genotype, ignore_hp)
     key = 'somatic' if out_key == 'somatic' else 'all'
     sample_ids = [target_id.replace('.bam' , '') for target_id in all_ids]
     


### PR DESCRIPTION
- Adds a new `--ignore-hp` CLI option that ignores BAM `HP`/`PS` tags during read parsing and coverage collection, treating the run as unphased end-to-end. 
- Updates breakpoint, graph, and VCF output paths so phased outputs are suppressed when this mode is enabled, and wires the new flag through the remaining VCF call path.