### PR TITLE
Fix `--ignore-hp` VCF output crash

### DIFF
--- a/severus/build_graph.py
+++ b/severus/build_graph.py
@@ -668,8 +668,4 @@ def output_graphs(db_list, coverage_histograms, thread_pool, target_genomes, con
         output_clusters_info(adj_clusters, out_cluster_list)
         
         logger.info("\tWriting vcf")
-        write_to_vcf(double_breaks, all_ids, out_folder, key, ref_lengths, args.no_ins, args.multisample, args.junction_vcf, args.germline_genotype)
-        
-            
-        
-    
+        write_to_vcf(double_breaks, all_ids, out_folder, key, ref_lengths, args.no_ins, args.multisample, args.junction_vcf, args.germline_genotype, args.ignore_hp)


### PR DESCRIPTION
Passes `args.ignore_hp` into the VCF writer from `output_graphs()`, matching the updated `write_to_vcf()` signature and preventing `--ignore-hp` runs from crashing at the VCF output step.

Sorry for the bug introduced earlier. It came from me reverting whitespace changes and accidentally reverting the `write_to_vcf()` call line back to the old argument list.